### PR TITLE
Only move client to default channel when it is not the TS default channel

### DIFF
--- a/ts3bot/bot.py
+++ b/ts3bot/bot.py
@@ -106,7 +106,8 @@ class Bot:
             self.exec_("servernotifyregister", event="server")
 
             # Move to target channel
-            self.exec_("clientmove", clid=self.own_id, cid=self.channel_id)
+            if current_nick[0]["client_channel_id"] != self.channel_id:
+                self.exec_("clientmove", clid=self.own_id, cid=self.channel_id)
 
     def exec_(self, cmd: str, *options, **params):
         return self.ts3c.exec_(cmd, *options, **params)


### PR DESCRIPTION
When the channel_id config setting is set to the same channel as the default channel in the TS server, the client will throw an exception upon joining. Compare the current client channel before moving the client to the new channel. This prevents the exception when starting the client.